### PR TITLE
FB-AddIQueryableToRepositories

### DIFF
--- a/src/GT86Registry.Core/Entities/Vehicle/ColorsModelYears.cs
+++ b/src/GT86Registry.Core/Entities/Vehicle/ColorsModelYears.cs
@@ -1,6 +1,6 @@
 ﻿namespace GT86Registry.Core.Entities
 {
-    public class ColorsModelYears
+    public class ColorsModelYears : BaseEntity
     {
         public int ColorId { get; set; }
         public Color Color { get; set; }

--- a/src/GT86Registry.Core/Interfaces/IRepository.cs
+++ b/src/GT86Registry.Core/Interfaces/IRepository.cs
@@ -1,5 +1,6 @@
 ﻿using GT86Registry.Core.Entities;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GT86Registry.Core.Interfaces
 {
@@ -11,6 +12,7 @@ namespace GT86Registry.Core.Interfaces
     {
         T GetById(int id);
         IEnumerable<T> GetAll();
+        IQueryable<T> GetAllQueryable();
         T AddEntity(T entity);
         void Add(T entity);
         void Update(T entity);

--- a/src/GT86Registry.Infrastructure/Data/EFRepository.cs
+++ b/src/GT86Registry.Infrastructure/Data/EFRepository.cs
@@ -46,9 +46,18 @@ namespace GT86Registry.Infrastructure.Data
             Delete(entity);
         }
 
+        /// <summary>
+        /// Gets all entities of type "T"
+        /// </summary>
+        /// <returns></returns>
         public IEnumerable<T> GetAll()
         {
             return _vehicleContext.Set<T>().AsEnumerable();
+        }
+
+        public IQueryable<T> GetAllQueryable()
+        {
+            return _vehicleContext.Set<T>();
         }
 
         public virtual T GetById(int id)

--- a/src/GT86Registry.Infrastructure/Data/Migrations/20180115201613_AddBaseEntityToColorModelsYears.Designer.cs
+++ b/src/GT86Registry.Infrastructure/Data/Migrations/20180115201613_AddBaseEntityToColorModelsYears.Designer.cs
@@ -12,9 +12,10 @@ using System;
 namespace GT86Registry.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(VehicleDbContext))]
-    partial class VehicleDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180115201613_AddBaseEntityToColorModelsYears")]
+    partial class AddBaseEntityToColorModelsYears
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/GT86Registry.Infrastructure/Data/Migrations/20180115201613_AddBaseEntityToColorModelsYears.cs
+++ b/src/GT86Registry.Infrastructure/Data/Migrations/20180115201613_AddBaseEntityToColorModelsYears.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace GT86Registry.Infrastructure.Data.Migrations
+{
+    public partial class AddBaseEntityToColorModelsYears : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreatedDate",
+                table: "Model_Color",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "ModifiedDate",
+                table: "Model_Color",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedDate",
+                table: "Model_Color");
+
+            migrationBuilder.DropColumn(
+                name: "ModifiedDate",
+                table: "Model_Color");
+        }
+    }
+}

--- a/src/GT86Registry.Web/Controllers/AccountController.cs
+++ b/src/GT86Registry.Web/Controllers/AccountController.cs
@@ -11,8 +11,6 @@ using GT86Registry.Web.Models.AccountViewModels;
 using GT86Registry.Web.Services;
 using GT86Registry.Infrastructure.Identity;
 using GT86Registry.Web.Interfaces;
-using GT86Registry.Infrastructure.Data;
-using GT86Registry.Core.Entities;
 
 namespace GT86Registry.Web.Controllers
 {

--- a/src/GT86Registry.Web/Controllers/AccountController.cs
+++ b/src/GT86Registry.Web/Controllers/AccountController.cs
@@ -26,7 +26,6 @@ namespace GT86Registry.Web.Controllers
         private readonly IEmailSender _emailSender;
         private readonly ILogger _logger;
         private readonly IVehicleViewModelService _vehicleService;
-        private readonly VehicleRepository _vehicleRepository;
         #endregion Properties
 
         #region Constructors
@@ -35,7 +34,6 @@ namespace GT86Registry.Web.Controllers
             SignInManager<ApplicationUser> signInManager,
             IEmailSender emailSender,
             IVehicleViewModelService vehicleService,
-            VehicleRepository vehicleRepository,
             ILogger<AccountController> logger)
         {
             _userManager = userManager;
@@ -43,7 +41,6 @@ namespace GT86Registry.Web.Controllers
             _emailSender = emailSender;
             _logger = logger;
             _vehicleService = vehicleService;
-            _vehicleRepository = vehicleRepository;
         }
         #endregion Constructors
 
@@ -224,7 +221,7 @@ namespace GT86Registry.Web.Controllers
         {
             RegisterViewModel vm = new RegisterViewModel
             {
-                Years = _vehicleService.GetAllYears().Result
+                Years = _vehicleService.GetAllYears()
             };
 
             ViewData["ReturnUrl"] = returnUrl;
@@ -233,16 +230,16 @@ namespace GT86Registry.Web.Controllers
 
         [HttpGet]
         [AllowAnonymous]
-        public async Task<IActionResult> GetManufacturersByYear(int year)
+        public IActionResult GetManufacturersByYear(int year)
         {
-            return Json(await _vehicleService.GetManufacturersByYear(year));
+            return Json(_vehicleService.GetManufacturersByYear(year));
         }
 
         [HttpGet]
         [AllowAnonymous]
-        public async Task<IActionResult> GetModels(int year, string manufacturer)
+        public IActionResult GetModels(int year, string manufacturer)
         {
-            return Json(await _vehicleService.GetModels(year, manufacturer));
+            return Json(_vehicleService.GetModels(year, manufacturer));
         }
 
         [HttpGet]

--- a/src/GT86Registry.Web/Controllers/AccountController.cs
+++ b/src/GT86Registry.Web/Controllers/AccountController.cs
@@ -247,9 +247,9 @@ namespace GT86Registry.Web.Controllers
 
         [HttpGet]
         [AllowAnonymous]
-        public async Task<IActionResult> GetColors(int year, string model)
+        public IActionResult GetColors(int year, string model)
         {
-            return Json(await _vehicleService.GetAvailableColorsForModel(year, model));
+            return Json(_vehicleService.GetAvailableColorsForModel(year, model));
         }
 
         [HttpPost]

--- a/src/GT86Registry.Web/Interfaces/IVehicleViewModelService.cs
+++ b/src/GT86Registry.Web/Interfaces/IVehicleViewModelService.cs
@@ -12,7 +12,7 @@ namespace GT86Registry.Web.Interfaces
         Task<IEnumerable<SelectListItem>> GetManufacturersByYear(int year);
         Task<IEnumerable<SelectListItem>> GetModels(int year, string manufacturer);
         Task<IEnumerable<SelectListItem>> GetAllYears();
-        Task<IEnumerable<SelectListItem>> GetAvailableColorsForModel(int year, string model);
+        IEnumerable<SelectListItem> GetAvailableColorsForModel(int year, string model);
 
 
     }

--- a/src/GT86Registry.Web/Interfaces/IVehicleViewModelService.cs
+++ b/src/GT86Registry.Web/Interfaces/IVehicleViewModelService.cs
@@ -12,5 +12,6 @@ namespace GT86Registry.Web.Interfaces
         IEnumerable<SelectListItem> GetModels(int year, string manufacturer);
         IEnumerable<SelectListItem> GetAllYears();
         IEnumerable<SelectListItem> GetAvailableColorsForModel(int year, string model);
+        IEnumerable<SelectListItem> GetTransmissionChoicesForModel(int year, string model);
     }
 }

--- a/src/GT86Registry.Web/Interfaces/IVehicleViewModelService.cs
+++ b/src/GT86Registry.Web/Interfaces/IVehicleViewModelService.cs
@@ -1,19 +1,16 @@
-﻿using GT86Registry.Core.Entities;
-using Microsoft.AspNetCore.Mvc.Rendering;
-using System;
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace GT86Registry.Web.Interfaces
 {
+    /// <summary>
+    /// Interface for a service which can be used to create VehicleViewModels
+    /// </summary>
     public interface IVehicleViewModelService
     {
-        Task<IEnumerable<SelectListItem>> GetManufacturersByYear(int year);
-        Task<IEnumerable<SelectListItem>> GetModels(int year, string manufacturer);
-        Task<IEnumerable<SelectListItem>> GetAllYears();
+        IEnumerable<SelectListItem> GetManufacturersByYear(int year);
+        IEnumerable<SelectListItem> GetModels(int year, string manufacturer);
+        IEnumerable<SelectListItem> GetAllYears();
         IEnumerable<SelectListItem> GetAvailableColorsForModel(int year, string model);
-
-
     }
 }

--- a/src/GT86Registry.Web/Services/VehicleViewModelService.cs
+++ b/src/GT86Registry.Web/Services/VehicleViewModelService.cs
@@ -17,13 +17,13 @@ namespace GT86Registry.Web.Services
         private readonly IAsyncRepository<ModelYear> _yearRepository;
         private readonly IAsyncRepository<Manufacturer> _manufacturerRepository;
         private readonly IAsyncRepository<Model> _vehicleModelRepository;
-        private readonly IAsyncRepository<Color> _colorsRepository;
+        private readonly IRepository<ColorsModelYears> _colorsRepository;
         private readonly VehicleDbContext _vehicleContext;
 
         public VehicleViewModelService(IAsyncRepository<ModelYear> yearRepository, 
                     IAsyncRepository<Manufacturer> manufacturerRepository,
                     IAsyncRepository<Model> vehicleModelRepository,
-                    IAsyncRepository<Color> colorRepository,
+                    IRepository<ColorsModelYears> colorRepository,
                     VehicleDbContext vehicleContext)
         {
             _yearRepository = yearRepository;
@@ -100,16 +100,14 @@ namespace GT86Registry.Web.Services
 
         }
         
-        public async Task<IEnumerable<SelectListItem>> GetAvailableColorsForModel(int year,  string model)
+        public IEnumerable<SelectListItem> GetAvailableColorsForModel(int year,  string model)
         {
-            // TODO (dca): query the join table instead
-            var colorChoices = _vehicleContext.ColorYears
-                                .Include(cy => cy.Color)
-                                .Include(cy => cy.ModelYear.Model)
-                                .Where(c => c.ModelYear.Year == year 
-                                    && c.ModelYear.Model.Name == model);
 
-            var colors = await _colorsRepository.ListAllAsync();
+            var colorChoices = _colorsRepository.GetAllQueryable()
+                            .Include(c => c.Color)
+                            .Include(c => c.ModelYear.Model)
+                            .Where(c => c.ModelYear.Year == year
+                                    && c.ModelYear.Model.Name == model);
 
             var items = new List<SelectListItem>
             {


### PR DESCRIPTION
Due to the nature of EF Core, I had to add IQueryable to my repository. This is a bit of a leaky abstraction, but it is a tradeoff I am willing to take in order to continue to use EF Core.

The issue is stemmed from the fact that we need access to a DbSet<T> so we can use `Include()` to load related entities. This doesn't work unless we use `IQueryable<T>`