### PR TITLE
Cleaning up duplicate refs to site name

### DIFF
--- a/src/GT86Registry.Web/Controllers/AccountController.cs
+++ b/src/GT86Registry.Web/Controllers/AccountController.cs
@@ -3,6 +3,7 @@ using GT86Registry.Core.Interfaces.Entities;
 using GT86Registry.Infrastructure.Identity;
 using GT86Registry.Web.Interfaces;
 using GT86Registry.Web.Models.AccountViewModels;
+using GT86Registry.Web.Models.Configuration;
 using GT86Registry.Web.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System;
 using System.Linq;
 using System.Security.Claims;
@@ -23,7 +25,6 @@ namespace GT86Registry.Web.Controllers
     {
         #region Properties
 
-        private readonly IConfiguration _configuration;
         private readonly IEmailSender _emailSender;
         private readonly ILogger _logger;
         private readonly SignInManager<ApplicationUser> _signInManager;
@@ -41,8 +42,8 @@ namespace GT86Registry.Web.Controllers
             IEmailSender emailSender,
             IVehicleViewModelService vehicleService,
             IVehicleFactory vehicleFactory,
-            ILogger<AccountController> logger,
-            IConfiguration configuration)
+            ILogger<AccountController> logger
+            )
         {
             _userManager = userManager;
             _signInManager = signInManager;
@@ -50,7 +51,6 @@ namespace GT86Registry.Web.Controllers
             _logger = logger;
             _vehicleService = vehicleService;
             _vehicleFactory = vehicleFactory;
-            _configuration = configuration;
         }
 
         #endregion Constructors
@@ -415,7 +415,7 @@ namespace GT86Registry.Web.Controllers
             {
                 Years = _vehicleService.GetAllYears()
             };
-            ViewData["VehiclePlatform"] = _configuration["SiteSettings:VehiclePlatform"];
+
             ViewData["ReturnUrl"] = returnUrl;
             return View(vm);
         }

--- a/src/GT86Registry.Web/Controllers/HomeController.cs
+++ b/src/GT86Registry.Web/Controllers/HomeController.cs
@@ -44,7 +44,7 @@ namespace GT86Registry.Web.Controllers
 
         public IActionResult Index()
         {
-            var vehicles = _vehicleService.GetVehicleOverviewViewModels();
+            var vehicles = _vehicleService.GetNewestRegisteredVehicles();
 
 
             ViewData["VehiclePlatform"] = _configuration["SiteSettings:VehiclePlatform"];

--- a/src/GT86Registry.Web/Controllers/HomeController.cs
+++ b/src/GT86Registry.Web/Controllers/HomeController.cs
@@ -1,9 +1,11 @@
 ﻿using GT86Registry.Infrastructure.Identity;
 using GT86Registry.Web.Interfaces;
 using GT86Registry.Web.Models;
+using GT86Registry.Web.Models.Configuration;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using System.Diagnostics;
 
 namespace GT86Registry.Web.Controllers
@@ -11,14 +13,19 @@ namespace GT86Registry.Web.Controllers
     public class HomeController : Controller
     {
         private readonly UserManager<ApplicationUser> _userManager;
-        private readonly IConfiguration _configuration;
         private readonly IVehicleViewModelService _vehicleService;
 
-        public HomeController(UserManager<ApplicationUser> userManager, IVehicleViewModelService vehicleService, IConfiguration configuration)
+        public HomeController(UserManager<ApplicationUser> userManager, IVehicleViewModelService vehicleService)
         {
             _userManager = userManager;
             _vehicleService = vehicleService;
-            _configuration = configuration;
+        }
+
+        public IActionResult Index()
+        {
+            var vehicles = _vehicleService.GetNewestRegisteredVehicles();
+
+            return View("../Vehicles/VehiclesIndex", vehicles);
         }
 
         [Route("/about")]
@@ -40,16 +47,6 @@ namespace GT86Registry.Web.Controllers
         public IActionResult Error()
         {
             return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
-        }
-
-        public IActionResult Index()
-        {
-            var vehicles = _vehicleService.GetNewestRegisteredVehicles();
-
-
-            ViewData["VehiclePlatform"] = _configuration["SiteSettings:VehiclePlatform"];
-            ViewData["Manufacturers"] = _configuration["SiteSettings:Manufacturers"];
-            return View("../Vehicles/VehiclesIndex", vehicles);
         }
     }
 }

--- a/src/GT86Registry.Web/Controllers/VehiclesController.cs
+++ b/src/GT86Registry.Web/Controllers/VehiclesController.cs
@@ -60,7 +60,7 @@ namespace GT86Registry.Web.Controllers
 
         public IActionResult Index()
         {
-            var vehicles = _vehicleService.GetVehicleOverviewViewModels();
+            var vehicles = _vehicleService.GetNewestRegisteredVehicles();
             ViewData["VehiclePlatform"] = _configuration["SiteSettings:VehiclePlatform"];
             ViewData["Manufacturers"] = _configuration["SiteSettings:Manufacturers"];
 
@@ -101,7 +101,6 @@ namespace GT86Registry.Web.Controllers
 
                 return View("Error", errorViewModel);
             }
-
 
             return View("~/Views/Account/UserProfile.cshtml", profile);
         }

--- a/src/GT86Registry.Web/Controllers/VehiclesController.cs
+++ b/src/GT86Registry.Web/Controllers/VehiclesController.cs
@@ -6,9 +6,7 @@ using GT86Registry.Web.Models.VehicleViewModels;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 
@@ -16,7 +14,6 @@ namespace GT86Registry.Web.Controllers
 {
     public class VehiclesController : Controller
     {
-        private readonly IConfiguration _configuration;
         private readonly ILogger<VehiclesController> _logger;
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly IUserProfileService _userProfileService;
@@ -28,7 +25,6 @@ namespace GT86Registry.Web.Controllers
             UserManager<ApplicationUser> userManager,
             IVehicleViewModelService vehicleService,
             IUserProfileService userProfileService,
-            IConfiguration configuration,
             ILogger<VehiclesController> logger
             )
         {
@@ -36,7 +32,6 @@ namespace GT86Registry.Web.Controllers
             _userManager = userManager;
             _vehicleService = vehicleService;
             _userProfileService = userProfileService;
-            _configuration = configuration;
             _logger = logger;
         }
 
@@ -61,8 +56,6 @@ namespace GT86Registry.Web.Controllers
         public IActionResult Index()
         {
             var vehicles = _vehicleService.GetNewestRegisteredVehicles();
-            ViewData["VehiclePlatform"] = _configuration["SiteSettings:VehiclePlatform"];
-            ViewData["Manufacturers"] = _configuration["SiteSettings:Manufacturers"];
 
             return View("VehiclesIndex", vehicles);
         }

--- a/src/GT86Registry.Web/Interfaces/Services/IVehicleViewModelService.cs
+++ b/src/GT86Registry.Web/Interfaces/Services/IVehicleViewModelService.cs
@@ -22,6 +22,8 @@ namespace GT86Registry.Web.Interfaces
 
         IEnumerable<VehicleOverviewViewModel> GetVehicleOverviewViewModels();
 
+        IEnumerable<VehicleOverviewViewModel> GetNewestRegisteredVehicles();
+
         Task<VehicleOverviewViewModel> GetVehicleOverviewViewModels(int pageIndex, int itemsPage, int? brandId, int? typeId);
     }
 }

--- a/src/GT86Registry.Web/Models/Configuration/SiteSettingsConfiguration.cs
+++ b/src/GT86Registry.Web/Models/Configuration/SiteSettingsConfiguration.cs
@@ -1,0 +1,22 @@
+﻿namespace GT86Registry.Web.Models.Configuration
+{
+    public class SiteSettingsConfiguration
+    {
+        public string[] Roles { get; set; }
+
+        /// <summary>
+        /// The name of the site (usually platform specific).
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The manufacturers associated with the vehicle platform the site is focused on.
+        /// </summary>
+        public string[] Manufacturers { get; set; }
+
+        /// <summary>
+        /// The platform code for the vehicle which this site is focused on.
+        /// </summary>
+        public string VehiclePlatform { get; set; }
+    }
+}

--- a/src/GT86Registry.Web/Models/VehicleViewModels/VehicleOverviewViewModel.cs
+++ b/src/GT86Registry.Web/Models/VehicleViewModels/VehicleOverviewViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using GT86Registry.Core.Entities;
+using System;
 
 namespace GT86Registry.Web.Models.VehicleViewModels
 {
@@ -13,6 +14,7 @@ namespace GT86Registry.Web.Models.VehicleViewModels
         public int Year { get; set; }
         public string Make { get; set; }
         public string Model { get; set; }
+        public DateTimeOffset CreatedDate { get; set; }
 
         public override string ToString()
         {

--- a/src/GT86Registry.Web/Services/VehicleViewModelService.cs
+++ b/src/GT86Registry.Web/Services/VehicleViewModelService.cs
@@ -174,7 +174,8 @@ namespace GT86Registry.Web.Services
                     VIN = vehicle.VIN,
                     Year = vehicle.ModelYear.Year,
                     Make = vehicle.ModelYear.Model.Manufacturer.Name,
-                    Model = vehicle.ModelYear.Model.Name
+                    Model = vehicle.ModelYear.Model.Name,
+                    CreatedDate = vehicle.CreatedDate
                 };
 
                 vehicleViewModels.Add(vm);
@@ -186,6 +187,13 @@ namespace GT86Registry.Web.Services
         public Task<VehicleOverviewViewModel> GetVehicleOverviewViewModels(int pageIndex, int itemsPage, int? brandId, int? typeId)
         {
             throw new System.NotImplementedException();
+        }
+
+        public IEnumerable<VehicleOverviewViewModel> GetNewestRegisteredVehicles()
+        {
+            var vehicles = GetVehicleOverviewViewModels().OrderByDescending(x => x.CreatedDate).Take(3);
+
+            return vehicles;
         }
     }
 }

--- a/src/GT86Registry.Web/Startup.cs
+++ b/src/GT86Registry.Web/Startup.cs
@@ -3,6 +3,7 @@ using GT86Registry.Core.Interfaces;
 using GT86Registry.Infrastructure.Data;
 using GT86Registry.Infrastructure.Identity;
 using GT86Registry.Web.Interfaces;
+using GT86Registry.Web.Models.Configuration;
 using GT86Registry.Web.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -91,6 +92,9 @@ namespace GT86Registry.Web
 
             // Add application services.
             services.AddTransient<IEmailSender, EmailSender>();
+
+            // Add Configuration
+            services.Configure<SiteSettingsConfiguration>(Configuration.GetSection("SiteSettings"));
 
             // Check out Ardalis article about why we need to use typeof here
             services.AddScoped(typeof(IRepository<>), typeof(EFRepository<>));

--- a/src/GT86Registry.Web/Views/Home/About.cshtml
+++ b/src/GT86Registry.Web/Views/Home/About.cshtml
@@ -4,7 +4,7 @@
 
 <div class="row">
     <div class="col-md-12">
-        <h1>What is GT86 Registry?</h1>
-        <p>GT86Registry.com was created by a car enthusiast who imagined a website dedicated to preserving and documenting information about the GT86 platform. This site allows GT86 owners to register their vehicle in our registry, thus preserving the history of their GT86.</p>
+        <h1>What is @SiteSettings.Value.VehiclePlatform Registry?</h1>
+        <p>@{@SiteSettings.Value.Name}.com was created by a car enthusiast who imagined a website dedicated to preserving and documenting information about the @SiteSettings.Value.VehiclePlatform platform. This site allows @SiteSettings.Value.VehiclePlatform owners to register their vehicle in our registry, thus preserving the history of their @SiteSettings.Value.VehiclePlatform.</p>
     </div>
 </div>

--- a/src/GT86Registry.Web/Views/Shared/_Layout.cshtml
+++ b/src/GT86Registry.Web/Views/Shared/_Layout.cshtml
@@ -7,7 +7,7 @@
     <link rel="icon" type="image/png" href="~/img/favicon.ico">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
-    <title>@ViewData["Title"] - GT86Registry.com</title>
+    <title>@ViewData["Title"] - @{@SiteSettings.Value.Name}.com</title>
 
     <meta content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0' name='viewport' />
     <meta name="viewport" content="width=device-width" />
@@ -127,14 +127,14 @@
                             </li>
                             <li>
                                 <a asp-area="" asp-controller="Home" asp-action="About">
-                                    About GT86Registry
+                                    About @SiteSettings.Value.Name
                                 </a>
                             </li>
                         </ul>
                     </nav>
                     <p class="copyright pull-right">
                         &copy;
-                        <script>document.write(new Date().getFullYear())</script> <a href="http://www.gt86registry.com">GT86Registry.com</a>
+                        <script>document.write(new Date().getFullYear())</script> <a href="http://www.gt86registry.com">@{@SiteSettings.Value.Name}.com</a>
                     </p>
                 </div>
             </footer>

--- a/src/GT86Registry.Web/Views/Shared/_LoginPartial.cshtml
+++ b/src/GT86Registry.Web/Views/Shared/_LoginPartial.cshtml
@@ -1,5 +1,4 @@
 @using Microsoft.AspNetCore.Identity
-@using GT86Registry.Web.Models
 @using GT86Registry.Infrastructure.Identity;
 
 @inject SignInManager<ApplicationUser> SignInManager
@@ -21,8 +20,6 @@
             <li><a href="/@UserName">View My Profile</a></li>
             <li><a asp-controller="Manage" asp-action="Index">Edit My Profile</a></li>
             <li><a asp-controller="Garage" asp-action="Index">View My Garage</a></li>
-            @*<li><a href="#">Another action</a></li>
-            <li><a href="#">Something</a></li>*@
             <li class="divider"></li>
             <li>
                 <form asp-area="" asp-controller="Account" asp-action="Logout" method="post" id="logoutForm" >

--- a/src/GT86Registry.Web/Views/Vehicles/Registry.cshtml
+++ b/src/GT86Registry.Web/Views/Vehicles/Registry.cshtml
@@ -12,7 +12,7 @@
         <div class="card">
             <div class="header">
                 <h4 class="title">There are currently <b>@Model.Count()</b> registered vehicles.</h4>
-                <p class="category">Do you own a GT86 and want to <a asp-controller="Account" asp-action="Register">join our community?</a></p>
+                <p class="category">Do you own a @SiteSettings.Value.VehiclePlatform and want to <a asp-controller="Account" asp-action="Register">join our community?</a></p>
             </div>
             <div class="content table-responsive table-full-width">
                 <table class="table table-hover table-striped">

--- a/src/GT86Registry.Web/Views/Vehicles/VehiclesIndex.cshtml
+++ b/src/GT86Registry.Web/Views/Vehicles/VehiclesIndex.cshtml
@@ -1,22 +1,25 @@
-﻿@model IEnumerable<VehicleOverviewViewModel>;
+﻿@model IEnumerable<VehicleOverviewViewModel>
+
 
 @{
-    ViewData["Title"] = "Home";
+        ViewData["Title"] = "Home";
 }
 
 <div class="row">
     <div class="col-md-12">
         <h1>
-            Welcome to the unofficial registry for the @ViewData["VehiclePlatform"] platform!
+            Welcome to the unofficial registry for the @SiteSettings.Value.VehiclePlatform platform!
         </h1>
         <p>
-            In 2012, Toyota and Subaru collaborated to produce the GT86, an iconic rear-wheel drive vehicle. The goal of this registry is to help GT86 owners document their vehicles and collaborate with fellow enthusiasts. 
+            In 2012, Toyota and Subaru collaborated to produce the @SiteSettings.Value.VehiclePlatform, an iconic rear-wheel drive vehicle. The goal of this registry is to help @SiteSettings.Value.VehiclePlatform owners document their vehicles and collaborate with fellow enthusiasts.
         </p>
-        <p>Do you own a GT86 and want to join our community?<a asp-controller="Account" asp-action="Register"> Register today for free!</a> Already a member? <a asp-controller="Account" asp-action="Register">Log in.</a></p>
 
-        <h2>Latest entries to the Registry
-            <small>View all</small>
-        </h2>
+        <h3>Do you own a @SiteSettings.Value.VehiclePlatform and want to join our community?</h3>
+        <p><a asp-controller="Account" asp-action="Register"> Register today for free!</a> Already a member? <a asp-controller="Account" asp-action="Register">Log in.</a></p>
+
+        <h3>Latest additions to the registry
+            <small><a asp-controller="Vehicles" asp-action="Registry">View all </a></small>
+        </h3>
     </div>
 </div>
 

--- a/src/GT86Registry.Web/Views/Vehicles/VehiclesIndex.cshtml
+++ b/src/GT86Registry.Web/Views/Vehicles/VehiclesIndex.cshtml
@@ -14,7 +14,9 @@
         </p>
         <p>Do you own a GT86 and want to join our community?<a asp-controller="Account" asp-action="Register"> Register today for free!</a> Already a member? <a asp-controller="Account" asp-action="Register">Log in.</a></p>
 
-        <h2>Our most recent members</h2>
+        <h2>Latest entries to the Registry
+            <small>View all</small>
+        </h2>
     </div>
 </div>
 

--- a/src/GT86Registry.Web/Views/_ViewImports.cshtml
+++ b/src/GT86Registry.Web/Views/_ViewImports.cshtml
@@ -1,4 +1,5 @@
 @using Microsoft.AspNetCore.Identity
+
 @using GT86Registry.Web.Models.AccountViewModels
 @using GT86Registry.Web.Models.ManageViewModels
 @using GT86Registry.Infrastructure.Identity
@@ -6,4 +7,9 @@
 @using GT86Registry.Core.Entities
 @using GT86Registry.Web.Models.VehicleViewModels
 @using GT86Registry.Web.Models
+
+@using GT86Registry.Web.Models.Configuration
+@using Microsoft.Extensions.Options
+@inject IOptions<SiteSettingsConfiguration> SiteSettings
+
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers


### PR DESCRIPTION
Removed duplicate references to the site platform and name, which are now just read in from config once.